### PR TITLE
Add rastermanip CLI commands

### DIFF
--- a/pyfastflow/cli/__init__.py
+++ b/pyfastflow/cli/__init__.py
@@ -6,11 +6,14 @@ easy access to common operations from the terminal without writing Python script
 
 Available Commands:
 - raster2npy: Convert raster files to numpy arrays
+- raster-upscale: Double raster resolution using rastermanip utilities
+- raster-downscale: Halve raster resolution using rastermanip utilities
 
 Author: B.G.
 """
 
 from .raster_commands import raster2npy
+from .rastermanip_commands import raster_downscale, raster_upscale
 
 # Export public API
-__all__ = ["raster2npy"]
+__all__ = ["raster2npy", "raster_upscale", "raster_downscale"]

--- a/pyfastflow/cli/rastermanip_commands.py
+++ b/pyfastflow/cli/rastermanip_commands.py
@@ -1,0 +1,98 @@
+"""CLI commands for raster resampling using PyFastFlow's rastermanip utilities."""
+
+import sys
+
+import click
+
+import pyfastflow as pf
+
+try:
+    import topotoolbox as ttb
+    from rasterio.transform import Affine, array_bounds
+    TOPOTOOLBOX_AVAILABLE = True
+except ImportError:  # pragma: no cover - handled in commands
+    TOPOTOOLBOX_AVAILABLE = False
+    ttb = None
+    Affine = None
+    array_bounds = None
+
+
+def _require_topotoolbox():
+    """Ensure TopoToolbox is available."""
+    if not TOPOTOOLBOX_AVAILABLE:
+        raise ImportError(
+            "TopoToolbox is required for this command. Install with: pip install topotoolbox"
+        )
+
+
+@click.command()
+@click.argument("input_raster", type=click.Path(exists=True))
+@click.argument("output_raster", type=click.Path())
+@click.option(
+    "--noise",
+    "-n",
+    default=0.0,
+    show_default=True,
+    type=float,
+    help="Noise amplitude to add during upscaling",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+def raster_upscale(input_raster, output_raster, noise, verbose):
+    """Double the resolution of INPUT_RASTER and save to OUTPUT_RASTER."""
+    try:
+        _require_topotoolbox()
+        if verbose:
+            click.echo(
+                f"Upscaling raster '{input_raster}' -> '{output_raster}' with noise={noise}"
+            )
+        grid = ttb.read_tif(input_raster)
+        result = pf.rastermanip.double_resolution(grid.z, noise_amplitude=noise)
+        grid.z = result.astype("float32")
+        grid.cellsize = grid.cellsize / 2
+        t = grid.transform
+        grid.transform = Affine(t.a / 2, t.b, t.c, t.d, t.e / 2, t.f)
+        grid.bounds = array_bounds(grid.rows, grid.columns, grid.transform)
+        ttb.write_tif(grid, output_raster)
+        if verbose:
+            click.echo("Upscaling completed successfully!")
+    except Exception as e:  # pragma: no cover - error handling path
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+@click.command()
+@click.argument("input_raster", type=click.Path(exists=True))
+@click.argument("output_raster", type=click.Path())
+@click.option(
+    "--method",
+    "-m",
+    type=click.Choice(["mean", "max", "min", "cubic"]),
+    default="mean",
+    show_default=True,
+    help="Aggregation method for downscaling",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+def raster_downscale(input_raster, output_raster, method, verbose):
+    """Halve the resolution of INPUT_RASTER and save to OUTPUT_RASTER."""
+    try:
+        _require_topotoolbox()
+        if verbose:
+            click.echo(
+                f"Downscaling raster '{input_raster}' -> '{output_raster}' using method='{method}'"
+            )
+        grid = ttb.read_tif(input_raster)
+        result = pf.rastermanip.halve_resolution(grid.z, method=method)
+        grid.z = result.astype("float32")
+        grid.cellsize = grid.cellsize * 2
+        t = grid.transform
+        grid.transform = Affine(t.a * 2, t.b, t.c, t.d, t.e * 2, t.f)
+        grid.bounds = array_bounds(grid.rows, grid.columns, grid.transform)
+        ttb.write_tif(grid, output_raster)
+        if verbose:
+            click.echo("Downscaling completed successfully!")
+    except Exception as e:  # pragma: no cover - error handling path
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+__all__ = ["raster_upscale", "raster_downscale"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ Issues = "https://github.com/bgailleton/fastflow_taichi/issues"
 
 [project.scripts]
 pff-raster2npy = "pyfastflow.cli.raster_commands:raster2npy"
+pff-upscale = "pyfastflow.cli.rastermanip_commands:raster_upscale"
+pff-downscale = "pyfastflow.cli.rastermanip_commands:raster_downscale"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,12 +1,12 @@
-"""
-Unit tests for CLI functionality.
-"""
+"""Unit tests for CLI functionality."""
+
+import numpy as np
 import pytest
 from click.testing import CliRunner
 
 
 class TestCLIRasterCommands:
-    """Test CLI raster conversion commands."""
+    """Test CLI raster conversion and manipulation commands."""
 
     @pytest.fixture
     def runner(self):
@@ -17,15 +17,71 @@ class TestCLIRasterCommands:
     def test_raster2npy_help(self, runner):
         """Test that raster2npy command shows help."""
         from pyfastflow.cli.raster_commands import raster2npy
-        
-        result = runner.invoke(raster2npy, ['--help'])
+
+        result = runner.invoke(raster2npy, ["--help"])
         assert result.exit_code == 0
-        assert 'Convert a raster file to numpy array format' in result.output
+        assert "Convert a raster file to numpy array format" in result.output
 
     @pytest.mark.unit
     def test_raster2npy_requires_args(self, runner):
         """Test that raster2npy requires arguments."""
         from pyfastflow.cli.raster_commands import raster2npy
-        
+
         result = runner.invoke(raster2npy, [])
         assert result.exit_code != 0  # Should fail without arguments
+
+    @pytest.mark.unit
+    def test_rastermanip_help(self, runner):
+        """Ensure rastermanip CLI commands show help text."""
+        from pyfastflow.cli.rastermanip_commands import raster_downscale, raster_upscale
+
+        res_up = runner.invoke(raster_upscale, ["--help"])
+        assert res_up.exit_code == 0
+        assert "Double the resolution" in res_up.output
+
+        res_down = runner.invoke(raster_downscale, ["--help"])
+        assert res_down.exit_code == 0
+        assert "Halve the resolution" in res_down.output
+
+    @pytest.mark.unit
+    def test_upscale_downscale_roundtrip(self, runner, tmp_path):
+        """Test raster upscaling and downscaling round-trip."""
+        from pyfastflow.cli.rastermanip_commands import (  # noqa: I001
+            raster_downscale,
+            raster_upscale,
+        )
+
+        pytest.importorskip("rasterio")
+        from rasterio.crs import CRS
+        from rasterio.transform import array_bounds, from_origin
+
+        ttb = pytest.importorskip("topotoolbox")
+
+        # create small raster
+        data = np.array([[1, 2], [3, 4]], dtype=np.float32)
+        go = ttb.GridObject()
+        go.z = data
+        go.cellsize = 1.0
+        go.transform = from_origin(0, 0, 1.0, 1.0)
+        go.georef = CRS.from_epsg(4326)
+        go.bounds = array_bounds(go.rows, go.columns, go.transform)
+        in_path = tmp_path / "in.tif"
+        ttb.write_tif(go, in_path)
+
+        # upscale
+        up_path = tmp_path / "up.tif"
+        result = runner.invoke(raster_upscale, [str(in_path), str(up_path)])
+        assert result.exit_code == 0
+        up = ttb.read_tif(up_path)
+        assert up.rows == 4
+        assert up.columns == 4
+
+        # downscale
+        down_path = tmp_path / "down.tif"
+        result = runner.invoke(
+            raster_downscale, [str(up_path), str(down_path), "--method", "mean"]
+        )
+        assert result.exit_code == 0
+        down = ttb.read_tif(down_path)
+        assert down.rows == 2
+        assert down.columns == 2


### PR DESCRIPTION
## Summary
- add `pff-upscale` and `pff-downscale` commands for raster resampling
- expose new commands in CLI package and project scripts
- test CLI round-trip upscaling and downscaling
- skip CLI roundtrip test when `rasterio` dependency is missing

## Testing
- `ruff check tests/unit/test_cli.py pyfastflow/cli/rastermanip_commands.py pyfastflow/cli/__init__.py pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89197b3108328bd5a051bca8a718e