### PR TITLE
Add precipitation map editor GUI and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ grid = pf.flow.GridField(nx, ny, dx, boundary_mode='custom')
 grid.set_boundaries(boundaries)
 ```
 
+### Precipitation Map Editor
+Create spatially variable precipitation or discharge inputs interactively:
+
+```bash
+pff-precip-gui dem.npy precip.npy --boundary boundaries.npy
+```
+
+Use the **Discharge input** checkbox to enter values in m³/s; they are internally converted to precipitation rates using the cell area. Switch between **Additive** painting (each cell receives the given value scaled by the brush) and **Distributed** painting where the total added over the selection equals the provided value. The resulting precipitation map is saved as a NumPy array.
+
 ### Stochastic Flow Routing
 ```python
 # Enable stochastic receivers

--- a/examples/precipitation_gui.py
+++ b/examples/precipitation_gui.py
@@ -1,0 +1,29 @@
+"""Example showing how to paint a precipitation map and use it."""
+
+import numpy as np
+import taichi as ti
+
+import pyfastflow as pf
+from pyfastflow.cli.precip_commands import precipitation_gui
+
+# Initialize Taichi (CPU backend for portability)
+ti.init(ti.cpu)
+
+# Paths to input/output files
+DEM_PATH = "dem.npy"
+BOUND_PATH = "boundaries.npy"
+PRECIP_PATH = "precip.npy"
+
+# Launch interactive editor (blocks until window is closed)
+precipitation_gui.main([DEM_PATH, PRECIP_PATH, "--boundary", BOUND_PATH])
+
+# Load results and plug into Flooder
+dem = np.load(DEM_PATH).astype(np.float32)
+precip = np.load(PRECIP_PATH).astype(np.float32)
+ny, nx = dem.shape
+
+grid = pf.flow.GridField(nx, ny, pf.constants.DX)
+grid.set_z(dem)
+
+flooder = pf.flood.Flooder(grid, precipitation_rates=precip)
+# Flooder can now be used for hydrodynamic simulations

--- a/pyfastflow/cli/__init__.py
+++ b/pyfastflow/cli/__init__.py
@@ -8,6 +8,7 @@ Available Commands:
 - raster2npy: Convert raster files to numpy arrays
 - raster-upscale: Double raster resolution using rastermanip utilities
 - raster-downscale: Halve raster resolution using rastermanip utilities
+- precip-gui: Interactive precipitation map editor
 
 Author: B.G.
 """
@@ -15,6 +16,13 @@ Author: B.G.
 from .raster_commands import raster2npy
 from .rastermanip_commands import raster_downscale, raster_upscale
 from .grid_commands import boundary_gui
+from .precip_commands import precipitation_gui
 
 # Export public API
-__all__ = ["raster2npy", "raster_upscale", "raster_downscale", "boundary_gui"]
+__all__ = [
+    "raster2npy",
+    "raster_upscale",
+    "raster_downscale",
+    "boundary_gui",
+    "precipitation_gui",
+]

--- a/pyfastflow/cli/precip_commands.py
+++ b/pyfastflow/cli/precip_commands.py
@@ -1,0 +1,5 @@
+"""CLI command for precipitation map editor."""
+
+from ..flood.precipitation_gui import precipitation_gui
+
+__all__ = ["precipitation_gui"]

--- a/pyfastflow/flood/__init__.py
+++ b/pyfastflow/flood/__init__.py
@@ -79,6 +79,7 @@ Author: B.G.
 # Import specific classes and functions from each module
 # Import modules themselves for module-level access
 from . import gf_fields, gf_hydrodynamics, gf_ls
+from .precipitation_gui import precipitation_gui
 from .gf_fields import Flooder
 from .gf_hydrodynamics import diffuse_Q_constant_prec, graphflood_core_cte_mannings
 from .gf_ls import (
@@ -104,4 +105,5 @@ __all__ = [
     "gf_fields",
     "gf_hydrodynamics",
     "gf_ls",
+    "precipitation_gui",
 ]

--- a/pyfastflow/flood/precipitation_gui.py
+++ b/pyfastflow/flood/precipitation_gui.py
@@ -1,0 +1,191 @@
+"""Interactive GUI to paint precipitation or discharge values on a DEM.
+
+This module offers a Taichi ``ggui`` based application similar to
+:mod:`pyfastflow.grid.boundary_gui`.  It loads a DEM stored as ``.npy`` file
+and lets the user interactively paint precipitation rates on top of it.  The
+value provided by the user can be interpreted either as precipitation rate
+(``m/s``) or discharge (``m^3/s``).  Internally the resulting array always
+stores precipitation rates; values entered as discharge are converted using
+the cell area (``cte.DX**2``).
+
+Two painting modes are available:
+
+* **Lasso** – draw a polygon selection and fill all cells inside.
+* **Gaussian brush** – paint with a circular Gaussian kernel.
+
+For both tools the user can choose between **additive** mode (each affected
+cell receives the full value scaled by the kernel) or **distributed** mode
+(the total added over the painted area equals the provided value).
+
+The GUI displays a hillshade background derived from the DEM.  If a boundary
+array is supplied, ``NoData`` (code ``0``) cells are shown in black and outlet
+nodes (code ``3``) in red to ease navigation.
+
+Example
+-------
+
+.. code-block:: bash
+
+    python -m pyfastflow.flood.precipitation_gui dem.npy precip.npy \
+        --boundary boundaries.npy
+
+Author
+------
+OpenAI's ChatGPT.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import click
+import taichi as ti
+from matplotlib.path import Path
+
+from ..visu.hillshading import hillshade_numpy
+from .. import constants as cte
+
+
+def _gaussian_kernel(radius: int) -> np.ndarray:
+    """Return a 2D Gaussian kernel with the given ``radius``."""
+
+    if radius <= 0:
+        return np.ones((1, 1), dtype=np.float32)
+    x = np.arange(-radius, radius + 1)
+    y = np.arange(-radius, radius + 1)
+    xx, yy = np.meshgrid(x, y)
+    sigma = radius / 2.0 if radius > 0 else 1.0
+    k = np.exp(-((xx**2 + yy**2) / (2.0 * sigma**2)))
+    return k.astype(np.float32)
+
+
+@click.command()
+@click.argument("dem_npy", type=click.Path(exists=True))
+@click.argument("output_npy", type=click.Path())
+@click.option(
+    "--boundary",
+    "boundary_npy",
+    type=click.Path(exists=True),
+    default=None,
+    help="Optional boundary array (.npy) for overlay.",
+)
+def precipitation_gui(
+    dem_npy: str, output_npy: str, boundary_npy: str | None
+) -> None:
+    """Launch the precipitation/discharge editor."""
+
+    dem = np.load(dem_npy).astype(np.float32)
+    ny, nx = dem.shape
+    precip = np.zeros((ny, nx), dtype=np.float32)
+
+    nodata = np.zeros_like(dem, dtype=bool)
+    outlets = np.zeros_like(dem, dtype=bool)
+    if boundary_npy is not None:
+        boundaries = np.load(boundary_npy).astype(np.uint8)
+        if boundaries.shape != dem.shape:
+            raise ValueError("Boundary array must match DEM dimensions")
+        nodata = boundaries == 0
+        outlets = boundaries == 3
+
+    hill = hillshade_numpy(dem, dx=cte.DX)
+    base_rgb = np.stack([hill, hill, hill], axis=-1)
+
+    ti.init(arch=ti.gpu if ti.core.is_arch_supported(ti.gpu) else ti.cpu)
+    window = ti.ui.Window("Precipitation Editor", (nx, ny))
+    canvas = window.get_canvas()
+    gui = window.get_gui()
+
+    value_slider = gui.slider_float("Value", 0.0, 1.0)
+    value_slider.value = 1.0
+    radius_slider = gui.slider_float("Radius", 1.0, 50.0)
+    radius_slider.value = 5.0
+
+    additive = False
+    discharge_mode = False
+    lasso_mode = False
+    lasso_path: list[tuple[float, float]] = []
+
+    img_field = ti.Vector.field(3, dtype=ti.f32, shape=(ny, nx))
+
+    def update_display() -> None:
+        rgb = base_rgb.copy()
+        max_p = float(precip.max())
+        if max_p > 0.0:
+            rgb[:, :, 2] = np.clip(rgb[:, :, 2] + precip / max_p, 0.0, 1.0)
+        rgb[nodata] = np.array([0.0, 0.0, 0.0])
+        rgb[outlets] = np.array([1.0, 0.0, 0.0])
+        img_field.from_numpy(rgb.astype(np.float32))
+
+    def apply_lasso(path: list[tuple[float, float]]) -> None:
+        if len(path) < 3:
+            return
+        poly = np.array([[p[0] * nx, (1.0 - p[1]) * ny] for p in path])
+        gx, gy = np.meshgrid(np.arange(nx), np.arange(ny))
+        pts = np.stack([gx.ravel(), gy.ravel()], axis=-1)
+        mask = Path(poly).contains_points(pts).reshape(ny, nx)
+        if not mask.any():
+            return
+        n = mask.sum()
+        val = value_slider.value
+        if discharge_mode:
+            val /= cte.DX * cte.DX
+        if additive:
+            precip[mask] += val
+        else:
+            precip[mask] += val / n
+
+    def apply_brush(pos: tuple[float, float]) -> None:
+        cx = int(pos[0] * nx)
+        cy = int((1.0 - pos[1]) * ny)
+        radius = int(radius_slider.value)
+        k = _gaussian_kernel(radius)
+        h, w = k.shape
+        x0 = max(cx - radius, 0)
+        y0 = max(cy - radius, 0)
+        x1 = min(cx + radius + 1, nx)
+        y1 = min(cy + radius + 1, ny)
+        sub_k = k[radius - (cy - y0) : radius + (y1 - cy),
+                  radius - (cx - x0) : radius + (x1 - cx)]
+        if additive:
+            weights = sub_k
+        else:
+            weights = sub_k / sub_k.sum()
+        val = value_slider.value
+        if discharge_mode:
+            val /= cte.DX * cte.DX
+        precip[y0:y1, x0:x1] += val * weights
+
+    update_display()
+    while window.running:
+        _ = value_slider.value  # keep widgets responsive
+        _ = radius_slider.value
+        additive = gui.checkbox("Additive", additive)
+        discharge_mode = gui.checkbox("Discharge input", discharge_mode)
+
+        if gui.button("Lasso"):
+            lasso_mode = True
+            lasso_path.clear()
+
+        if gui.button("Save and Quit"):
+            np.save(output_npy, precip)
+            break
+
+        if lasso_mode:
+            if window.is_pressed(ti.ui.LMB):
+                lasso_path.append(window.get_cursor_pos())
+            elif lasso_path:
+                apply_lasso(lasso_path)
+                lasso_path.clear()
+                lasso_mode = False
+        else:
+            if window.is_pressed(ti.ui.LMB):
+                apply_brush(window.get_cursor_pos())
+
+        update_display()
+        canvas.set_image(img_field)
+        window.show()
+
+    window.destroy()
+
+
+if __name__ == "__main__":
+    precipitation_gui()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pff-raster2npy = "pyfastflow.cli.raster_commands:raster2npy"
 pff-upscale = "pyfastflow.cli.rastermanip_commands:raster_upscale"
 pff-downscale = "pyfastflow.cli.rastermanip_commands:raster_downscale"
 pff-boundary-gui = "pyfastflow.cli.grid_commands:boundary_gui"
+pff-precip-gui = "pyfastflow.cli.precip_commands:precipitation_gui"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             "pff-upscale=pyfastflow.cli.rastermanip_commands:raster_upscale",
             "pff-downscale=pyfastflow.cli.rastermanip_commands:raster_downscale",
             "pff-boundary-gui=pyfastflow.cli.grid_commands:boundary_gui",
+            "pff-precip-gui=pyfastflow.cli.precip_commands:precipitation_gui",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- Implement Taichi ggui precipitation editor supporting lasso and Gaussian brush painting with discharge-to-precipitation conversion
- Expose the editor via new `pff-precip-gui` CLI command and document usage
- Provide example script demonstrating how to paint and load precipitation maps

## Testing
- `pytest`

